### PR TITLE
kconfig-mode: add ?= to the syntax table as a separator

### DIFF
--- a/kconfig-mode.el
+++ b/kconfig-mode.el
@@ -53,6 +53,10 @@
 
     ;; `_' as being a valid part of a word
     (modify-syntax-entry ?_ "w" syntax-table)
+
+    ;; `=' as a separator.
+    ;; e.g. HOTPLUG_PCI=y
+    (modify-syntax-entry ?= "-" syntax-table)
     syntax-table)
   "Syntax table for `kconfig-mode'.")
 


### PR DESCRIPTION
The original code doesn't work unexpectedly when picking
a configuration name with (thing-at-point 'symnol) if the
point is at a character within

    HOTPLUG_PCI=y

. thing-at-point picks up whole "HOTPLUG_PCI=y" though
"HOTPLUG_PCI" is expected.

Adding ?= to the syntax table as a separator, it works
unexpectedly.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>